### PR TITLE
￼ fix for link in markdown

### DIFF
--- a/mdx_latex.py
+++ b/mdx_latex.py
@@ -523,7 +523,7 @@ class Link2Latex(object):
         desc = re.search(r'>([^<]+)', instr)
         out = \
             """
-            \\href{%s}{%s}
+            \\\href{%s}{%s}
             """ % (href, desc.group(0)[1:])
         return out
 


### PR DESCRIPTION
Hi,

I fixed the exception when using a link in markdown code. See issue https://github.com/rufuspollock/markdown2latex/issues/6